### PR TITLE
Added login system

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
 
     </dependencies>
 

--- a/src/main/java/pl/radeko/scoreapp/api/AuthApi.java
+++ b/src/main/java/pl/radeko/scoreapp/api/AuthApi.java
@@ -1,0 +1,85 @@
+package pl.radeko.scoreapp.api;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.web.servlet.view.RedirectView;
+import pl.radeko.scoreapp.manager.AuthManager;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Controller
+@RequestMapping("/api/auth/")
+public class AuthApi {
+
+    private final AuthManager auths;
+
+    @Autowired
+    public AuthApi(AuthManager auths) {
+        this.auths = auths;
+    }
+
+
+    @GetMapping("/login")
+    public String showLoginForm() {
+        return "auth/login";
+    }
+
+    @PostMapping("/login")
+    public RedirectView login(@RequestParam String username, @RequestParam String password, HttpServletRequest request, RedirectAttributes redirectAttributes) {
+        // checking whether the given data is correct
+        if (auths.login(username, password, request)) {
+            // redirection to main page after successful login
+            return new RedirectView("/api/teams/index");
+        } else {
+            redirectAttributes.addFlashAttribute("message", "Wystąpił błąd podczas logowania");
+            // displaying an error and leaving  the user on the login page
+            return new RedirectView("/api/auth/login");
+        }
+    }
+
+    @GetMapping("/register")
+    public String showRegistrationForm() {
+        return "auth/register";
+    }
+
+    @PostMapping("/register")
+    public RedirectView register(@RequestParam String username, @RequestParam String password, RedirectAttributes redirectAttributes) {
+        // checking, if username is not taken
+        if (auths.register(username, password)) {
+            // displaying a success info and redirection to login page after registration
+            redirectAttributes.addFlashAttribute("message", "Rejestracja zakończona pomyślnie.");
+            return new RedirectView("/api/auth/login");
+        } else {
+            // displaying an error and leaving the user on the registration page
+            redirectAttributes.addFlashAttribute("message", "Wystąpił błąd podczas rejestracji.");
+            return new RedirectView("/api/auth/register");
+        }
+    }
+
+/*
+    @PreAuthorize("hasAuthority(Role.ADMIN.name())")
+    @GetMapping("/api/admin/users")
+    public List<User> getAllUsers() {
+        return userRepository.findAll();
+    }
+
+    @GetMapping("/api/users")
+    public List<User> getAllUsers(Authentication authentication) {
+        List<User> users = new ArrayList<>();
+        if (authentication.getAuthorities().contains(new SimpleGrantedAuthority(Role.ADMIN.name()))) {
+            users = userRepository.findAll();
+        } else if (authentication.getAuthorities().contains(new SimpleGrantedAuthority(Role.USER.name()))) {
+            Optional<User> user = userRepository.findByUsername(authentication.getName());
+            if(user.isPresent()) {
+                users.add(user.get());
+            }
+        }
+        return users;
+    }*/
+
+}

--- a/src/main/java/pl/radeko/scoreapp/config/AuthConfiguration.java
+++ b/src/main/java/pl/radeko/scoreapp/config/AuthConfiguration.java
@@ -1,0 +1,47 @@
+package pl.radeko.scoreapp.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import pl.radeko.scoreapp.manager.CustomUserDetailsManager;
+
+@Configuration
+@EnableWebSecurity
+public class AuthConfiguration extends WebSecurityConfigurerAdapter {
+    @Autowired
+    private CustomUserDetailsManager userDetailsService;
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+    @Bean
+    @Override
+    public AuthenticationManager authenticationManagerBean() throws Exception {
+        return super.authenticationManagerBean();
+    }
+
+    @Override
+    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+        auth.userDetailsService(userDetailsService).passwordEncoder(passwordEncoder());
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http.authorizeRequests()
+                .antMatchers("/", "/api/auth/login*", "/api/auth/register").permitAll()
+                .anyRequest().authenticated()
+                .and()
+                .formLogin().loginPage("/api/auth/login")
+                .defaultSuccessUrl("/", true).permitAll()
+                .and()
+                .logout().permitAll();
+    }
+}

--- a/src/main/java/pl/radeko/scoreapp/manager/AuthManager.java
+++ b/src/main/java/pl/radeko/scoreapp/manager/AuthManager.java
@@ -1,0 +1,83 @@
+package pl.radeko.scoreapp.manager;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.view.RedirectView;
+import pl.radeko.scoreapp.repository.UserRepository;
+import pl.radeko.scoreapp.repository.entity.User;
+import pl.radeko.scoreapp.repository.enums.Role;
+
+import javax.annotation.PostConstruct;
+import javax.servlet.ServletRegistration;
+import javax.servlet.http.HttpServletRequest;
+
+@Service
+public class AuthManager {
+
+    private final UserRepository userRepository;
+    private final BCryptPasswordEncoder passwordEncoder;
+    private final AuthenticationManager authenticationManager;
+
+    @Autowired
+    public AuthManager(UserRepository userRepository, BCryptPasswordEncoder passwordEncoder, AuthenticationManager authenticationManager) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.authenticationManager = authenticationManager;
+    }
+
+
+    public boolean login(String username, String password, HttpServletRequest request){
+        Authentication authentication = authenticationManager.authenticate(
+            new UsernamePasswordAuthenticationToken(username, password)
+        );
+        if (authentication != null) {
+            // saving the authentication in the session
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            request.getSession().setAttribute("SPRING_SECURITY_CONTEXT", SecurityContextHolder.getContext());
+            return true;
+        }
+            return false;
+    }
+
+    public boolean register(String username, String password){
+        if (!userRepository.findByUsername(username).isPresent()) {
+            // creating new user
+            User user = new User();
+            user.setUsername(username);
+            user.setPassword(passwordEncoder.encode(password));
+            user.setRole(Role.USER); // assigning default role
+            userRepository.save(user);
+            return true;
+        }
+        return false;
+    }
+
+    @Value("${scoreapp.defaultLogin}")
+    private String login;
+    @Value("${scoreapp.defaultPassword}")
+    private String password;
+    @PostConstruct
+    public void createAdminAccount() {
+        // create an account if it doesn't exist
+        if (!userRepository.findByUsername(login).isPresent()) {
+            User admin = new User();
+            admin.setUsername(login);
+            admin.setPassword(passwordEncoder.encode(password));
+            admin.setRole(Role.ADMIN);
+            userRepository.save(admin);
+            return;
+        }
+        // force the admin to have password the same as in application.properties
+        User admin = userRepository.findByUsername("admin").get();
+        if (!passwordEncoder.matches(password, admin.getPassword())) {
+            admin.setPassword(passwordEncoder.encode(password));
+            userRepository.save(admin);
+        }
+    }
+}

--- a/src/main/java/pl/radeko/scoreapp/manager/CustomUserDetailsManager.java
+++ b/src/main/java/pl/radeko/scoreapp/manager/CustomUserDetailsManager.java
@@ -1,0 +1,35 @@
+package pl.radeko.scoreapp.manager;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import pl.radeko.scoreapp.repository.UserRepository;
+import pl.radeko.scoreapp.repository.entity.User;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class CustomUserDetailsManager implements UserDetailsService {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Optional<User> optionalUser = userRepository.findByUsername(username);
+        if (!optionalUser.isPresent()) {
+            throw new UsernameNotFoundException("Nie znaleziono użytkownika o podanej nazwie");
+        }
+        User user = optionalUser.get();
+        return new org.springframework.security.core.userdetails.User(
+                user.getUsername(),
+                user.getPassword(),
+                List.of(new SimpleGrantedAuthority(user.getRole().name()))
+        );
+    }
+}

--- a/src/main/java/pl/radeko/scoreapp/repository/UserRepository.java
+++ b/src/main/java/pl/radeko/scoreapp/repository/UserRepository.java
@@ -1,0 +1,16 @@
+package pl.radeko.scoreapp.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+import pl.radeko.scoreapp.repository.entity.User;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends CrudRepository<User, Long> {
+
+    Optional<User> findByUsername(String username);
+    List<User> findAll();
+}
+

--- a/src/main/java/pl/radeko/scoreapp/repository/entity/User.java
+++ b/src/main/java/pl/radeko/scoreapp/repository/entity/User.java
@@ -1,0 +1,74 @@
+package pl.radeko.scoreapp.repository.entity;
+
+import pl.radeko.scoreapp.repository.enums.Role;
+
+import javax.persistence.*;
+
+
+@Entity
+@Table(name = "Users")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @Column(name="username")
+    private String username;
+    @Column(name="password")
+    private String password;
+    @Column(name="role")
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    public User() {
+        this.username = "";
+        this.password = "";
+        this.role = Role.USER;
+    }
+    public User(String username) {
+        this.username = username;
+        this.password = ""; //TODO random password generator
+        this.role = Role.USER;
+    }
+    public User(String username, String password, Role role) {
+        this.username = username;
+        this.password = password;
+        this.role = role;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public Role getRole() {
+        return role;
+    }
+
+    public void setRole(Role role) {
+        this.role = role;
+    }
+
+    @Override
+    public String toString() {
+        return "User{" +
+                "id=" + id +
+                ", username='" + username + '\'' +
+                ", password='" + password + '\'' +
+                ", role=" + role +
+                '}';
+    }
+}

--- a/src/main/java/pl/radeko/scoreapp/repository/enums/Role.java
+++ b/src/main/java/pl/radeko/scoreapp/repository/enums/Role.java
@@ -1,0 +1,5 @@
+package pl.radeko.scoreapp.repository.enums;
+
+public enum Role {
+    ADMIN, USER, MODERATOR
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,4 +29,6 @@ spring.web.resources.static-locations[1]=classpath:/static/
 
 scoreapp.numberOfTeams=32
 scoreapp.sizeOfGroup=4
-
+#default credentials
+scoreapp.defaultLogin=admin
+scoreapp.defaultPassword=admin

--- a/src/main/resources/templates/auth/login.html
+++ b/src/main/resources/templates/auth/login.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="pl" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Logowanie</title>
+</head>
+<body>
+<h1>Logowanie</h1>
+<p th:if="${param.error}" class="alert alert-error">
+    Wystąpił błąd podczas logowania. Prawodopodobnie nazwa użytkownika, lub hasło są nieprawidłowe.
+</p>
+<p th:if="${param.logout}" class="alert alert-success">
+    Wylogowano.
+</p>
+<p th:if="${message}" th:text="${message}"></p>
+<form action="#" th:action="@{/api/auth/login}" method="post">
+    <label for="username">Nazwa użytkownika:</label><br>
+    <input type="text" id="username" name="username"><br>
+    <label for="password">Hasło:</label><br>
+    <input type="password" id="password" name="password"><br><br>
+    <input type="submit" value="Zaloguj się">
+</form>
+</body>
+</html>

--- a/src/main/resources/templates/auth/register.html
+++ b/src/main/resources/templates/auth/register.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="pl" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Rejestracja</title>
+</head>
+<body>
+<h1>Rejestracja</h1>
+<p th:if="${message}" th:text="${message}"></p>
+<form action="#" th:action="@{/api/auth/register}" method="post">
+    <label for="username">Nazwa użytkownika:</label><br>
+    <input type="text" id="username" name="username"><br>
+    <label for="password">Hasło:</label><br>
+    <input type="password" id="password" name="password"><br><br>
+    <input type="submit" value="Zarejestruj się">
+</form>
+</body>
+</html>


### PR DESCRIPTION
login page on endpoint `/api/auth/login`
registration page on endpoint `/api/auth/register`
You're redirected to login page when you're not logged in and you choosen eligible endpoint.
 The only eligible endpoints at the moment are:
- `/` 
- `/api/auth/login` 
- `/api/auth/register` 

The only way to go to registration page is by manually changing the URL
default credentials: 
{**Username**: `admin`, **Password**: `admin`}

Credentials will always reset on re-runing the code
When database is set to update mode -> changing username will create additional user.
Check `AuthManager.java` `void createAdminAccount()` for further details.